### PR TITLE
fix: remove model from the carousel as one is not defined

### DIFF
--- a/blocks/carousel/_carousel.json
+++ b/blocks/carousel/_carousel.json
@@ -8,8 +8,7 @@
           "page": {
             "resourceType": "core/franklin/components/block/v1/block",
             "template": {
-              "name": "Carousel",
-              "model": "carousel",
+              "name": "Carousel",              
               "filter": "carousel"
             }
           }


### PR DESCRIPTION
Remove non defined model from the carousel.